### PR TITLE
Rework continuation mechanism

### DIFF
--- a/samples/Eff.Examples.CancellationToken/Program.cs
+++ b/samples/Eff.Examples.CancellationToken/Program.cs
@@ -22,7 +22,7 @@ namespace Eff.Examples.CancellationToken
             }
         }
 
-        static async Task Main(string[] args)
+        static async Task Main()
         {
             var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
             var handler = new CustomEffectHandler(cts.Token);

--- a/samples/Eff.Examples.Config/Program.cs
+++ b/samples/Eff.Examples.Config/Program.cs
@@ -9,7 +9,6 @@ namespace Eff.Examples.Config
 {
     class Program
     {
-
         public static async Eff<string> Foo()
         {
             var google = await Effect.Config("google");
@@ -18,7 +17,7 @@ namespace Eff.Examples.Config
             return $"{google} - {microsoft}";
         }
 
-        static async Task Main(string[] args)
+        static async Task Main()
         {
             var handler = new CustomEffectHandler();
             var result = await Foo().Run(handler);

--- a/samples/Eff.Examples.Console/Program.cs
+++ b/samples/Eff.Examples.Console/Program.cs
@@ -35,7 +35,7 @@ namespace Eff.Examples.Console
                         done = true;
                         break;
                     case Delay<T> delay:
-                        eff = delay.Func(delay.State);
+                        eff = delay.Continuation.Trigger();
                         break;
                     case Await<T> awaitEff:
                         switch (awaitEff.Effect)
@@ -50,7 +50,7 @@ namespace Eff.Examples.Console
                             default:
                                 throw new NotSupportedException($"{awaitEff.Effect.GetType().Name}");
                         }
-                        eff = awaitEff.Continuation(awaitEff.State);
+                        eff = awaitEff.Continuation.Trigger();
                         break;
                     default:
                         throw new NotSupportedException($"{eff.GetType().Name}");
@@ -60,7 +60,7 @@ namespace Eff.Examples.Console
             return result;
         }
 
-        static void Main(string[] args)
+        static void Main()
         {
             Run(Foo());
         }

--- a/samples/Eff.Examples.NonDeterminism/Effects.cs
+++ b/samples/Eff.Examples.NonDeterminism/Effects.cs
@@ -11,13 +11,9 @@ namespace Eff.Examples.NonDeterminism
 
     public static class Effect
     {
-        public static NonDetEffect<T> Choose<T>(T[] choices,
-                                            [CallerMemberName] string memberName = "",
-                                            [CallerFilePath] string sourceFilePath = "",
-                                            [CallerLineNumber] int sourceLineNumber = 0,
-                                            bool captureState = false)
+        public static NonDetEffect<T> Choose<T>(params T[] choices)
         {
-            return new NonDetEffect<T>(choices, memberName, sourceFilePath, sourceLineNumber, captureState);
+            return new NonDetEffect<T>(choices);
         }
 
         public static List<TResult> Run<TResult>(this Eff<TResult> eff)
@@ -29,7 +25,7 @@ namespace Eff.Examples.NonDeterminism
                 case SetResult<TResult> setResult:
                     return new List<TResult> { setResult.Result };
                 case Delay<TResult> delay:
-                    return Run(delay.Func(delay.State));
+                    return Run(delay.Continuation.Trigger());
                 case Await<TResult> awaitEff:
                     var handler = new NonDetHandler<TResult>(awaitEff.Continuation);
                     var effect = awaitEff.Effect;

--- a/samples/Eff.Examples.NonDeterminism/Effects.cs
+++ b/samples/Eff.Examples.NonDeterminism/Effects.cs
@@ -28,8 +28,7 @@ namespace Eff.Examples.NonDeterminism
                     return Run(delay.Continuation.Trigger());
                 case Await<TResult> awaitEff:
                     var handler = new NonDetHandler<TResult>(awaitEff.Continuation);
-                    var effect = awaitEff.Effect;
-                    effect.Accept(handler);
+                    awaitEff.Effect.Accept(handler);
                     return handler.Results;
                 default:
                     throw new NotSupportedException($"{eff.GetType().Name}");

--- a/samples/Eff.Examples.NonDeterminism/NonDetEffect.cs
+++ b/samples/Eff.Examples.NonDeterminism/NonDetEffect.cs
@@ -10,16 +10,11 @@ namespace Eff.Examples.NonDeterminism
 {
     public class NonDetEffect<T> : Effect<T>
     {
-
-        public NonDetEffect(T[] choices, 
-                            string memberName, string sourceFilePath, int sourceLineNumber, bool captureState)
-            : base(memberName, sourceFilePath, sourceLineNumber)
+        public NonDetEffect(T[] choices)
         {
             Choices = choices;
         }
 
         public T[] Choices { get; }
-
     }
-
 }

--- a/samples/Eff.Examples.NonDeterminism/NonDetEffectHandler.cs
+++ b/samples/Eff.Examples.NonDeterminism/NonDetEffectHandler.cs
@@ -12,38 +12,26 @@ namespace Eff.Examples.NonDeterminism
 {
     public class NonDetHandler<TResult> : EffectHandler
     {
-        private readonly List<TResult> results = new List<TResult>();
-        private readonly Func<object, Eff<TResult>> continuation;
+        private readonly IContinuation<TResult> _continuation;
 
-        public List<TResult> Results => results;
-
-        public NonDetHandler(Func<object, Eff<TResult>> continuation)
+        public NonDetHandler(IContinuation<TResult> continuation)
         {
-            this.continuation = continuation;
+            _continuation = continuation;
         }
 
-        private static object Clone(object obj) 
-        {
-            MethodInfo info = obj.GetType().GetMethod("MemberwiseClone",
-                BindingFlags.Instance | BindingFlags.NonPublic);
-            
-            return info.Invoke(obj, null);
-            
-        }
+        public List<TResult> Results { get; } = new List<TResult>();
 
         public async override Task Handle<TValue>(IEffect<TValue> effect)
         {
             switch (effect)
             {
-                case NonDetEffect<TValue> _effect:
+                case NonDetEffect<TValue> nde:
                     
-                    foreach (var choice in _effect.Choices)
+                    foreach (var choice in nde.Choices)
                     {
                         effect.SetResult(choice);
-                        var state = _effect.State;
-                        object _state = Clone(state);
-                        var result = Effect.Run(continuation(_state));
-                        results.AddRange(result);
+                        var results = Effect.Run(_continuation.Clone().Trigger());
+                        Results.AddRange(results);
                     }
                     break;
             }

--- a/samples/Eff.Examples.NonDeterminism/NonDetEffectHandler.cs
+++ b/samples/Eff.Examples.NonDeterminism/NonDetEffectHandler.cs
@@ -30,7 +30,7 @@ namespace Eff.Examples.NonDeterminism
                     foreach (var choice in nde.Choices)
                     {
                         effect.SetResult(choice);
-                        var results = Effect.Run(_continuation.Clone().Trigger());
+                        var results = Effect.Run(_continuation.Trigger(useClonedStateMachine: true));
                         Results.AddRange(results);
                     }
                     break;

--- a/samples/Eff.Examples.NonDeterminism/Program.cs
+++ b/samples/Eff.Examples.NonDeterminism/Program.cs
@@ -12,12 +12,12 @@ namespace Eff.Examples.NonDeterminism
 
         static async Eff<(int, string)> Foo()
         {
-            var x = await Effect.Choose(new[] { 1, 2, 3 });
-            var y = await Effect.Choose(new[] { "one", "two", "three" });
+            var x = await Effect.Choose(1, 2, 3);
+            var y = await Effect.Choose("one", "two", "three");
             return (x, y);
         }
 
-        static void Main(string[] args)
+        static void Main()
         {
             var results = Foo().Run();
             foreach (var result in results)

--- a/samples/Eff.Examples.RecordReplay/Program.cs
+++ b/samples/Eff.Examples.RecordReplay/Program.cs
@@ -19,7 +19,7 @@ namespace Eff.Examples.RecordReplay
             return (now, rnd);
         }
 
-        static async Task Main(string[] args)
+        static async Task Main()
         {
             var handler = new RecordEffectHandler(new EffCtx { Random = new Random() });
             var result = await Foo().Run(handler);

--- a/samples/Eff.Examples.StackTrace/CustomEffectHandler.cs
+++ b/samples/Eff.Examples.StackTrace/CustomEffectHandler.cs
@@ -51,8 +51,8 @@ namespace Eff.Examples.StackTrace
                     CallerLineNumber = effect.CallerLineNumber,
                     CallerMemberName = effect.CallerMemberName,
                     Exception = ex,
-                    Parameters = Eff.Core.Utils.GetParametersValues(effect.State),
-                    LocalVariables = Eff.Core.Utils.GetLocalVariablesValues(effect.State),
+                    Parameters = Eff.Core.TraceHelpers.GetParametersValues(effect.State),
+                    LocalVariables = Eff.Core.TraceHelpers.GetLocalVariablesValues(effect.State),
                 };
             if (!ex.Data.Contains("StackTraceLog"))
             {

--- a/samples/Eff.Examples.StackTrace/Program.cs
+++ b/samples/Eff.Examples.StackTrace/Program.cs
@@ -27,7 +27,7 @@ namespace Eff.Examples.StackTrace
             return y + z;
         }
 
-        static async Task Main(string[] args)
+        static async Task Main()
         {
             try
             {

--- a/samples/Eff.Examples.TraceLog/CustomEffectHandler.cs
+++ b/samples/Eff.Examples.TraceLog/CustomEffectHandler.cs
@@ -39,8 +39,8 @@ namespace Eff.Examples.TraceLog
                     CallerLineNumber = effect.CallerLineNumber,
                     CallerMemberName = effect.CallerMemberName,
                     Result = result,
-                    Parameters = Eff.Core.Utils.GetParametersValues(effect.State),
-                    LocalVariables = Eff.Core.Utils.GetLocalVariablesValues(effect.State),
+                    Parameters = Eff.Core.TraceHelpers.GetParametersValues(effect.State),
+                    LocalVariables = Eff.Core.TraceHelpers.GetLocalVariablesValues(effect.State),
                 };
             TraceLogs.Add(log);
         }

--- a/samples/Eff.Examples.TraceLog/Program.cs
+++ b/samples/Eff.Examples.TraceLog/Program.cs
@@ -1,9 +1,7 @@
 ﻿#pragma warning disable 1998
 using Eff.Core;
+using Eff.Core.ImplicitAwaitables;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Eff.Examples.TraceLog
@@ -21,12 +19,12 @@ namespace Eff.Examples.TraceLog
             int sum = 0;
             for (int i = 0; i < n; i++)
             {
-                sum += await Bar(i).AsEffect();
+                sum += await Bar(i);
             }
             return sum;
         }
 
-        static async Task Main(string[] args)
+        static async Task Main()
         {
             var handler = new CustomEffectHandler();
             await Foo(10).Run(handler);

--- a/src/Eff.Core/Eff.cs
+++ b/src/Eff.Core/Eff.cs
@@ -59,7 +59,6 @@ namespace Eff.Core
     public interface IContinuation<TResult>
     {
         object State { get; set; }
-        Eff<TResult> Trigger();
-        IContinuation<TResult> Clone();
+        Eff<TResult> Trigger(bool useClonedStateMachine = false);
     }
 }

--- a/src/Eff.Core/Eff.cs
+++ b/src/Eff.Core/Eff.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 
 namespace Eff.Core
 {
+
     [AsyncMethodBuilder(typeof(EffMethodBuilder<>))]
     public abstract class Eff<TResult>
     {
@@ -11,16 +12,14 @@ namespace Eff.Core
 
     public class Await<TResult> : Eff<TResult>
     {
-        public Await(IEffect effect, Func<object, Eff<TResult>> continuation, object state)
+        public Await(IEffect effect, IContinuation<TResult> continuation)
         {
             Effect = effect;
             Continuation = continuation;
-            State = state;
         }
 
         public IEffect Effect { get; }
-        public Func<object, Eff<TResult>> Continuation { get; }
-        public object State { get; }
+        public IContinuation<TResult> Continuation { get; }
     }
 
     public class SetResult<TResult> : Eff<TResult>
@@ -49,13 +48,18 @@ namespace Eff.Core
 
     public class Delay<TResult> : Eff<TResult>
     {
-        public Delay(Func<object, Eff<TResult>> func, object state)
+        public Delay(IContinuation<TResult> continuation)
         {
-            Func = func;
-            State = state;
+            Continuation = continuation;
         }
 
-        public Func<object, Eff<TResult>> Func { get; }
-        public object State { get; }
+        public IContinuation<TResult> Continuation { get; }
+    }
+
+    public interface IContinuation<TResult>
+    {
+        object State { get; set; }
+        Eff<TResult> Trigger();
+        IContinuation<TResult> Clone();
     }
 }

--- a/src/Eff.Core/EffMethodBuilder.cs
+++ b/src/Eff.Core/EffMethodBuilder.cs
@@ -1,36 +1,57 @@
 ﻿using System;
+using System.Linq;
+using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 using System.Security;
+using System.Reflection;
+using System.ComponentModel;
 
 namespace Eff.Core
 {
-    public class EffMethodBuilder<TResult>
+    public class EffMethodBuilder<TResult> : IContinuation<TResult>
     {
-        private object? _state;
-        private Func<object, Eff<TResult>>? _continuation;
+        private IAsyncStateMachine? _state;
+        private bool _isClonedInstance = false;
 
         public Eff<TResult>? Task { get; private set; }
 
+        private EffMethodBuilder() 
+        {
+
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static EffMethodBuilder<TResult> Create()
         {
             return new EffMethodBuilder<TResult>();
         }
 
+        public Eff<TResult> Trigger()
+        {
+            // ensure original state machine is never run
+            // this is to guarantee thread safety of delayed Eff instances
+            var builder = _isClonedInstance ? this : CloneBuilder();
+            builder._state!.MoveNext();
+            return builder.Task!;
+        }
+
+        public object State
+        {
+            get => _state!;
+            set => _state = (IAsyncStateMachine)value;
+        }
+
+        public IContinuation<TResult> Clone() => CloneBuilder();
+
         public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine
         {
             _state = stateMachine;
-            _continuation = state =>
-            {
-                _state = state;
-                ((IAsyncStateMachine)state).MoveNext();
-                return Task!;
-            };
-            Task = new Delay<TResult>(_continuation, _state);
+            Task = new Delay<TResult>(this);
         }
 
-        public void SetStateMachine(IAsyncStateMachine stateMachine)
+        public void SetStateMachine(IAsyncStateMachine _)
         {
-            
+
         }
 
         public void SetResult(TResult result)
@@ -59,7 +80,7 @@ namespace Eff.Core
             AwaitOnCompleted(ref awaiter, ref stateMachine, false);
         }
 
-        private void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine, bool safe)
+        private void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine _, bool safe)
             where TAwaiter : IEffect
             where TStateMachine : IAsyncStateMachine
         {
@@ -68,12 +89,37 @@ namespace Eff.Core
             {
                 case IEffect effect:
                     effect.SetState(_state!);
-                    Task = new Await<TResult>(effect, _continuation!, _state!);
+                    Task = new Await<TResult>(effect, this);
 
                     break;
                 default:
                     throw new EffException($"Awaiter {awaiter.GetType().Name} is not an effect. Try to use obj.AsEffect().");
             }
         }
+
+        private EffMethodBuilder<TResult> CloneBuilder()
+        {
+            if (_state is null)
+            {
+                throw new InvalidOperationException("Cannot clone uninitialized state machine builder");
+            }
+
+            var clonedBuilder = new EffMethodBuilder<TResult>();
+            var stateMachineRefl = s_cloneRefl.GetOrAdd(_state.GetType(), GetMembers);
+            var clonedStateMachine = (IAsyncStateMachine)stateMachineRefl.memberwiseClone.Invoke(_state, null);
+            stateMachineRefl.builder?.SetValue(clonedStateMachine, clonedBuilder);
+            clonedBuilder._state = clonedStateMachine;
+            clonedBuilder._isClonedInstance = true;
+            return clonedBuilder;
+
+            static (MethodInfo, FieldInfo?) GetMembers(Type type)
+            {
+                var memberwiseClone = type.GetMethod("MemberwiseClone", BindingFlags.Instance | BindingFlags.NonPublic);
+                var field = type.GetFields(BindingFlags.Instance | BindingFlags.Public).Where(f => f.FieldType == typeof(EffMethodBuilder<TResult>)).FirstOrDefault();
+                return (memberwiseClone, field);
+            }
+        }
+
+        private static readonly ConcurrentDictionary<Type, (MethodInfo memberwiseClone, FieldInfo? builder)> s_cloneRefl = new ConcurrentDictionary<Type, (MethodInfo, FieldInfo?)>();
     }
 }

--- a/src/Eff.Core/Effect.cs
+++ b/src/Eff.Core/Effect.cs
@@ -10,7 +10,7 @@ namespace Eff.Core
         protected Exception? _exception;
         protected object? _state;
 
-        public Effect(string memberName, string sourceFilePath, int sourceLineNumber)
+        public Effect(string memberName = "", string sourceFilePath = "", int sourceLineNumber = 0)
         {
             CallerMemberName = memberName;
             CallerFilePath = sourceFilePath;
@@ -33,7 +33,7 @@ namespace Eff.Core
         {
             // TODO: make compatible with Task.Result semantics
 
-            if (_exception != null)
+            if (!(_exception is null))
             {
                 System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(_exception).Throw();
                 throw _exception;

--- a/src/Eff.Core/EffectExtensions.cs
+++ b/src/Eff.Core/EffectExtensions.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 
 namespace Eff.Core
 {
-    public static class Effect
+    public static class EffectExtensions
     {
         public static TaskEffect<TResult> AsEffect<TResult>(this Task<TResult> task,
                                                     [CallerMemberName] string memberName = "",
@@ -30,5 +30,15 @@ namespace Eff.Core
         {
             return new EffEffect<TResult>(eff, memberName, sourceFilePath, sourceLineNumber);
         }
+    }
+}
+
+namespace Eff.Core.ImplicitAwaitables
+{
+    public static class ImplicitAwaitableExtensions
+    {
+        public static TaskEffect<TResult> GetAwaiter<TResult>(this Task<TResult> task) => task.AsEffect();
+        public static TaskEffect<ValueTuple> GetAwaiter<TResult>(this Task task) => task.AsEffect();
+        public static EffEffect<TResult> GetAwaiter<TResult>(this Eff<TResult> eff) => eff.AsEffect();
     }
 }

--- a/src/Eff.Core/EffectHandler.cs
+++ b/src/Eff.Core/EffectHandler.cs
@@ -12,6 +12,8 @@ namespace Eff.Core
             
         }
 
+        public virtual bool CloneDelayedStateMachines { get; set; } = false;
+
         public abstract Task Handle<TResult>(IEffect<TResult> effect);
        
         public virtual async Task Handle<TResult>(TaskEffect<TResult> effect)
@@ -38,7 +40,7 @@ namespace Eff.Core
 
         public virtual async Task<Eff<TResult>> Handle<TResult>(Delay<TResult> delay)
         {
-            return delay.Continuation.Trigger();
+            return delay.Continuation.Trigger(useClonedStateMachine: CloneDelayedStateMachines);
         }
 
         public virtual async Task<Eff<TResult>> Handle<TResult>(Await<TResult> awaitEff)

--- a/src/Eff.Core/EffectHandler.cs
+++ b/src/Eff.Core/EffectHandler.cs
@@ -7,7 +7,6 @@ namespace Eff.Core
 {
     public abstract class EffectHandler : IEffectHandler
     {
-
         public EffectHandler()
         {
             
@@ -39,7 +38,7 @@ namespace Eff.Core
 
         public virtual async Task<Eff<TResult>> Handle<TResult>(Delay<TResult> delay)
         {
-            return delay.Func(delay.State);
+            return delay.Continuation.Trigger();
         }
 
         public virtual async Task<Eff<TResult>> Handle<TResult>(Await<TResult> awaitEff)
@@ -61,7 +60,7 @@ namespace Eff.Core
                 effect.SetException(ex);
             }
 
-            var eff = awaitEff.Continuation(awaitEff.State);
+            var eff = awaitEff.Continuation.Trigger();
             return eff;
         }
     }

--- a/src/Eff.Core/TraceHelpers.cs
+++ b/src/Eff.Core/TraceHelpers.cs
@@ -5,10 +5,10 @@ using System.Reflection;
 
 namespace Eff.Core
 {
-    public static class Utils
+    public static class TraceHelpers
     {
-        private static ConcurrentDictionary<Type, (string name, FieldInfo fieldInfo)[]> parametersInfoCache = new ConcurrentDictionary<Type, (string name, FieldInfo fieldInfo)[]>();
-        private static ConcurrentDictionary<Type, (string name, FieldInfo fieldInfo)[]> localVariablesInfoCache = new ConcurrentDictionary<Type, (string name, FieldInfo fieldInfo)[]>();
+        private static readonly ConcurrentDictionary<Type, (string name, FieldInfo fieldInfo)[]> s_parametersInfoCache = new ConcurrentDictionary<Type, (string name, FieldInfo fieldInfo)[]>();
+        private static readonly ConcurrentDictionary<Type, (string name, FieldInfo fieldInfo)[]> s_localVariablesInfoCache = new ConcurrentDictionary<Type, (string name, FieldInfo fieldInfo)[]>();
         private static (string name, object value)[] GetValues((string name, FieldInfo fieldInfo)[] fieldsInfo, object state)
         {
             var result = new(string name, object value)[fieldsInfo.Length];
@@ -43,14 +43,14 @@ namespace Eff.Core
 
         public static (string name, object value)[] GetParametersValues(object state)
         {
-            var parametersInfo = parametersInfoCache.GetOrAdd(state.GetType(), _ => Utils.GetParametersInfo(state));
+            var parametersInfo = s_parametersInfoCache.GetOrAdd(state.GetType(), _ => TraceHelpers.GetParametersInfo(state));
 
             return GetValues(parametersInfo, state);
         }
 
         public static (string name, object value)[] GetLocalVariablesValues(object state)
         {
-            var localVariablesInfo = localVariablesInfoCache.GetOrAdd(state.GetType(), _ => Utils.GetLocalVariablesInfo(state));
+            var localVariablesInfo = s_localVariablesInfoCache.GetOrAdd(state.GetType(), _ => TraceHelpers.GetLocalVariablesInfo(state));
 
             return GetValues(localVariablesInfo, state); ;
         }

--- a/tests/Eff.Tests/EffectTests.cs
+++ b/tests/Eff.Tests/EffectTests.cs
@@ -333,7 +333,7 @@ namespace Eff.Tests
             }
 
             var eff = Foo();
-            var handler = new DefaultEffectHandler();
+            var handler = new DefaultEffectHandler() { CloneDelayedStateMachines = true };
 
             Assert.Equal(0, counter);
             await Task.WhenAll(Enumerable.Range(0, 100).Select(_ => Task.Run(() => eff.Run(handler))));

--- a/tests/Eff.Tests/TestEffectHandler.cs
+++ b/tests/Eff.Tests/TestEffectHandler.cs
@@ -45,8 +45,8 @@ namespace Eff.Core
         public (string name, object value)[] CaptureStateLocalVariables { private set; get; }
         public override async Task Handle<TResult>(TaskEffect<TResult> effect)
         {
-            CaptureStateParameters = Utils.GetParametersValues(effect.State);
-            CaptureStateLocalVariables = Utils.GetLocalVariablesValues(effect.State);
+            CaptureStateParameters = TraceHelpers.GetParametersValues(effect.State);
+            CaptureStateLocalVariables = TraceHelpers.GetLocalVariablesValues(effect.State);
 
             try
             {
@@ -86,8 +86,8 @@ namespace Eff.Core
                     CallerLineNumber = effect.CallerLineNumber,
                     CallerMemberName = effect.CallerMemberName,
                     Exception = ex,
-                    Parameters = Utils.GetParametersValues(effect.State),
-                    LocalVariables = Utils.GetLocalVariablesValues(effect.State),
+                    Parameters = TraceHelpers.GetParametersValues(effect.State),
+                    LocalVariables = TraceHelpers.GetLocalVariablesValues(effect.State),
                 };
             ExceptionLogs.Add(log);
 
@@ -114,8 +114,8 @@ namespace Eff.Core
                     CallerLineNumber = effect.CallerLineNumber,
                     CallerMemberName = effect.CallerMemberName,
                     Result = result,
-                    Parameters = Utils.GetParametersValues(effect.State),
-                    LocalVariables = Utils.GetLocalVariablesValues(effect.State),
+                    Parameters = TraceHelpers.GetParametersValues(effect.State),
+                    LocalVariables = TraceHelpers.GetLocalVariablesValues(effect.State),
                 };
             TraceLogs.Add(log);
             return ValueTuple.Create();


### PR DESCRIPTION
* Reworks continuation mechanism so that state machine interpretation can be made thread safe.
* Adds an `Eff.Core.ImplicitAwaitables` namespace which, if opened, removes the need for explicit `AsEffect()` calls. Intended for simpler introductory examples.