### PR TITLE
Simplify `Unit` implementation via record

### DIFF
--- a/src/Eff/Unit.cs
+++ b/src/Eff/Unit.cs
@@ -9,7 +9,7 @@ namespace Nessos.Effects
     ///   While similar to <see cref="Void"/>, the unit type is inhabited 
     ///   by a single materialized value and can be used as a generic parameter.
     /// </remarks>
-    public readonly struct Unit : IEquatable<Unit>
+    public readonly record struct Unit
     {
         /// <summary>
         ///   Gets the Unit instance.
@@ -17,13 +17,7 @@ namespace Nessos.Effects
         public static Unit Value => new();
         /// Implements unit hashcode
         public override int GetHashCode() => 1;
-        /// Implements unit equality
-        public override bool Equals(object? obj) => obj is Unit;
-        /// Implements unit equality
-        public bool Equals(Unit other) => true;
-        /// Implements unit equality
-        public static bool operator ==(Unit x, Unit y) => true;
-        /// Implements unit inequality
-        public static bool operator !=(Unit x, Unit y) => false;
+        /// Implements string representation of unit
+        public override string ToString() => "()";
     }
 }

--- a/src/Eff/Unit.cs
+++ b/src/Eff/Unit.cs
@@ -15,7 +15,6 @@ namespace Nessos.Effects
         ///   Gets the Unit instance.
         /// </summary>
         public static Unit Value => new();
-        /// Implements unit hashcode
         /// Implements string representation of unit
         public override string ToString() => "()";
     }

--- a/src/Eff/Unit.cs
+++ b/src/Eff/Unit.cs
@@ -16,7 +16,6 @@ namespace Nessos.Effects
         /// </summary>
         public static Unit Value => new();
         /// Implements unit hashcode
-        public override int GetHashCode() => 1;
         /// Implements string representation of unit
         public override string ToString() => "()";
     }


### PR DESCRIPTION
This PR simplifies `Unit` by turning it into a _value record_ and letting the compiler generate most members in the interest of lowering maintenance.

I've kept `GetHashCode` so that it continues to return 1. I doubted anyone is relying on it, but it can help avoid conflicts (in hashing buckets) if someone is using `Unit?` as keys, where hash of a `default(Unit?)` will return 0 and 1 if a `Unit?` is some _unit_. If this is not needed, and once again I doubted anyone is counting on that, I can also remove it.

The `ToString()` implementation is also changed to return `()` (the default would have returned `Unit { }`), whereas it returned `Nessos.Effects.Unit` previously. If compatibility is important then I can revert to returning `Nessos.Effects.Unit`.